### PR TITLE
Update AbstractPaynlResponse.php

### DIFF
--- a/src/Message/Response/AbstractPaynlResponse.php
+++ b/src/Message/Response/AbstractPaynlResponse.php
@@ -18,7 +18,12 @@ abstract class AbstractPaynlResponse extends AbstractResponse
      */
     public function isSuccessful()
     {
-        return isset($this->data['request']['result']) && $this->data['request']['result'] == 1;
+        if($this->data['request']['result'] == 1){
+            if($this->data['paymentDetails']['state'] == 100){
+                return true;
+            }
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
When cancelling a transaction at the pay.nl website you'll get a succesful transaction status and thus the transaction is marked as paid. I've added a check to make sure that the paymentDetails.state is 100 (succesful transaction). If it is not 100 then OmniPay will pick up the transaction status and handle the rest of the process.