### PR TITLE
Implement RedirectResponse for PurchaseResponse

### DIFF
--- a/src/Message/Response/PurchaseResponse.php
+++ b/src/Message/Response/PurchaseResponse.php
@@ -2,8 +2,9 @@
 
 namespace Omnipay\Paynl\Message\Response;
 
+use Omnipay\Common\Message\RedirectResponseInterface;
 
-class PurchaseResponse extends AbstractPaynlResponse
+class PurchaseResponse extends AbstractPaynlResponse implements RedirectResponseInterface
 {
     /**
      * When you do a `purchase` the request is never successful because

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -4,9 +4,11 @@ namespace Omnipay\Paynl\Test\Message;
 
 
 use Omnipay\Common\CreditCard;
+use Omnipay\Common\Message\RedirectResponseInterface;
 use Omnipay\Paynl\Message\Request\PurchaseRequest;
 use Omnipay\Paynl\Message\Response\PurchaseResponse;
 use Omnipay\Tests\TestCase;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class PurchaseRequestTest extends TestCase
 {
@@ -35,6 +37,8 @@ class PurchaseRequestTest extends TestCase
 
         $this->assertEquals('GET', $response->getRedirectMethod());
         $this->assertNull($response->getRedirectData());
+        $this->assertInstanceOf(RedirectResponseInterface::class, $response);
+        $this->assertInstanceOf(RedirectResponse::class, $response->getRedirectResponse());
     }
 
     public function testCardEnduser()


### PR DESCRIPTION
This is required to make the redirect()/redirectResponse() methods work. 